### PR TITLE
Fixed so YAML plugin checks are seen as valid by main compliance-checker

### DIFF
--- a/checklib/code/nc_util.py
+++ b/checklib/code/nc_util.py
@@ -29,7 +29,7 @@ def get_main_variable(ds):
         sizes[ncvar] = dsv[ncvar].size
 
     mx_size = max(sizes.values())
-    if sizes.values().count(mx_size) > 1:
+    if list(sizes.values()).count(mx_size) > 1:
         raise Exception("More than one 'main' variable found in netCDF4 file.")
 
     return [dsv[ncvar] for ncvar, size in sizes.items() if dsv[ncvar].size == mx_size][0]

--- a/checklib/register/callable_check_base.py
+++ b/checklib/register/callable_check_base.py
@@ -1,3 +1,7 @@
+
+from netCDF4 import Dataset
+
+from compliance_checker import MemoizedDataset
 from compliance_checker.base import BaseCheck, Dataset, Result
 from checklib.code.errors import FileError, ParameterError
 
@@ -13,7 +17,7 @@ class CallableCheckBase(object):
     required_args = []
     message_templates = []
     level = BaseCheck.HIGH
-    supported_ds = [Dataset]
+    supported_ds = {Dataset, MemoizedDataset}
 
     def __init__(self, kwargs, messages=None, level="HIGH", vocabulary_ref=None):
         self.kwargs = self.defaults.copy()


### PR DESCRIPTION
A couple of lines changed, to make our Base Check class match the signature of the main Check Base class in the compliance checker:

```
diff --git a/checklib/register/callable_check_base.py b/checklib/register/callable_check_base.py
index 41df325..5a2376f 100644
--- a/checklib/register/callable_check_base.py
+++ b/checklib/register/callable_check_base.py
@@ -1,3 +1,7 @@
+
+from netCDF4 import Dataset
+
+from compliance_checker import MemoizedDataset
 from compliance_checker.base import BaseCheck, Dataset, Result
 from checklib.code.errors import FileError, ParameterError

@@ -13,7 +17,7 @@ class CallableCheckBase(object):
     required_args = []
     message_templates = []
     level = BaseCheck.HIGH
-    supported_ds = [Dataset]
+    supported_ds = {Dataset, MemoizedDataset}
```

